### PR TITLE
Fix function in URI Links section of ref docs

### DIFF
--- a/src/docs/asciidoc/web/web-uris.adoc
+++ b/src/docs/asciidoc/web/web-uris.adoc
@@ -71,7 +71,8 @@ as the following example shows:
 	URI uri = UriComponentsBuilder
 			.fromUriString("https://example.com/hotels/{hotel}")
 			.queryParam("q", "{q}")
-			.build("Westin", "123");
+			.build("Westin", "123")
+			.toUri();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
@@ -80,6 +81,7 @@ as the following example shows:
 			.fromUriString("https://example.com/hotels/{hotel}")
 			.queryParam("q", "{q}")
 			.build("Westin", "123")
+			.toUri()
 ----
 
 You can shorten it further still with a full URI template, as the following example shows:
@@ -89,7 +91,8 @@ You can shorten it further still with a full URI template, as the following exam
 ----
 	URI uri = UriComponentsBuilder
 			.fromUriString("https://example.com/hotels/{hotel}?q={q}")
-			.build("Westin", "123");
+			.build("Westin", "123")
+			.toUri();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
@@ -97,6 +100,7 @@ You can shorten it further still with a full URI template, as the following exam
 	val uri = UriComponentsBuilder
 		.fromUriString("https://example.com/hotels/{hotel}?q={q}")
 		.build("Westin", "123")
+		.toUri()
 ----
 
 
@@ -180,7 +184,8 @@ that holds configuration and preferences, as the following example shows:
 
 	URI uri = uriBuilderFactory.uriString("/hotels/{hotel}")
 			.queryParam("q", "{q}")
-			.build("Westin", "123");
+			.build("Westin", "123")
+			.toUri();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
@@ -191,6 +196,7 @@ that holds configuration and preferences, as the following example shows:
 	val uri = uriBuilderFactory.uriString("/hotels/{hotel}")
 			.queryParam("q", "{q}")
 			.build("Westin", "123")
+			.toUri()
 ----
 
 
@@ -252,7 +258,8 @@ as the following example shows:
 ----
 	URI uri = UriComponentsBuilder.fromPath("/hotel list/{city}")
 			.queryParam("q", "{q}")
-			.build("New York", "foo+bar");
+			.build("New York", "foo+bar")
+			.toUri();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
@@ -260,6 +267,7 @@ as the following example shows:
 	val uri = UriComponentsBuilder.fromPath("/hotel list/{city}")
 			.queryParam("q", "{q}")
 			.build("New York", "foo+bar")
+			.toUri()
 ----
 
 You can shorten it further still with a full URI template, as the following example shows:
@@ -268,13 +276,15 @@ You can shorten it further still with a full URI template, as the following exam
 .Java
 ----
 	URI uri = UriComponentsBuilder.fromUriString("/hotel list/{city}?q={q}")
-			.build("New York", "foo+bar");
+			.build("New York", "foo+bar")
+			.toUri();
 ----
 [source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
 .Kotlin
 ----
 	val uri = UriComponentsBuilder.fromUriString("/hotel list/{city}?q={q}")
 			.build("New York", "foo+bar")
+			.toUri()
 ----
 
 The `WebClient` and the `RestTemplate` expand and encode URI templates internally through


### PR DESCRIPTION
Just fix the same function invoke like this:
```java
URI uri = UriComponentsBuilder
        .fromUriString("https://example.com/hotels/{hotel}?q={q}")
        .build("Westin", "123");
```
↓
```java
URI uri = UriComponentsBuilder
        .fromUriString("https://example.com/hotels/{hotel}?q={q}")
        .build("Westin", "123")
        .toUri(); // need to create a URI from this instance
```